### PR TITLE
refactor: simplify release workflow and update registry image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,11 @@
 name: Release
 
 on:
-  push:
-    tags:
-    - "v*.*.*"
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version number'
-      skip_gh_release:
-        description: 'Skip creating a GitHub release'
-        required: false
-        default: false
-        type: boolean
+  push:    
+  workflow_dispatch:    
 
 env:
-  REGISTRY_IMAGE: ghcr.io/agentgateway/agentgateway
+  REGISTRY_IMAGE: ghcr.io/denispalnitsky/agentgateway
 
 jobs:
   build-image:
@@ -245,100 +235,3 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}-musl
-
-  build:
-    if: ${{ github.event_name == 'push' || ! github.event.inputs.skip_gh_release }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            # Performance is horrendous on musl without jemalloc
-            features: jemalloc
-          - os: ubuntu-22.04-arm
-            target: aarch64-unknown-linux-musl
-            # TODO: arm64 build fails with jemalloc for some reason?
-            features: default
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            features: default
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            features: default
-    steps:
-    - name: Prepare
-      run: |
-        echo "VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 23
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: ${{ matrix.target }}
-    # TODO: build this in a separate job and just copy it over
-    - name: Build UI
-      run: |
-        cd ui
-        npm install
-        npm run build
-    - name: Install musl-tools
-      if: ${{ matrix.os == 'ubuntu-22.04-arm' || matrix.os == 'ubuntu-latest' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y musl-tools
-        rustup target add ${{ matrix.target }}
-    - name: Build
-      run: make build
-      env:
-        CARGO_BUILD_ARGS: "--target ${{ matrix.target }} -F ${{ matrix.features }}"
-    - name: Debug dirty build
-      run: |
-        git status
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-binary-${{ matrix.os }}
-        path: |
-          target/${{ matrix.target }}/release/agentgateway
-          target/${{ matrix.target }}/release/agentgateway.exe
-
-  release:
-    if: ${{ github.event_name == 'push' || ! github.event.inputs.skip_gh_release }}
-    needs:
-    - push-image
-    - musl-push-image
-    - build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-    - name: Download Artifacts
-      uses: actions/download-artifact@v4
-      with:
-        pattern: release-binary-*
-
-    - name: Display structure of downloaded files
-      run: |
-        ls -R
-        mkdir outputs
-        mv release-binary-macos-latest/agentgateway outputs/agentgateway-darwin-arm64
-        sha256sum outputs/agentgateway-darwin-arm64 > outputs/agentgateway-darwin-arm64.sha256
-        mv release-binary-ubuntu-latest/agentgateway outputs/agentgateway-linux-amd64
-        sha256sum outputs/agentgateway-linux-amd64 > outputs/agentgateway-linux-amd64.sha256
-        mv release-binary-ubuntu-22.04-arm/agentgateway outputs/agentgateway-linux-arm64
-        sha256sum outputs/agentgateway-linux-arm64 > outputs/agentgateway-linux-arm64.sha256
-        mv release-binary-windows-latest/agentgateway.exe outputs/agentgateway-windows-amd64.exe
-        sha256sum outputs/agentgateway-windows-amd64.exe > outputs/agentgateway-windows-amd64.exe.sha256
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: outputs/agentgateway-*
-        tag_name: ${{ github.ref_name }}
-        body: "Automated release of ${{ github.ref_name }}."
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         platform=${{ matrix.platform }}
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
         echo "VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
+        echo "GIT_HASH=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
     - name: Docker meta
       id: meta
@@ -78,6 +79,10 @@ jobs:
     needs:
       - build-image
     steps:
+      - name: Prepare
+        run: |
+          echo "GIT_HASH=${GITHUB_SHA::7}" >> $GITHUB_ENV
+          
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2
 
@@ -104,9 +109,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-            type=semver,pattern={{version}}
-            # use custom value instead of git tag
-            type=semver,pattern={{version}},value=${{ github.event.inputs.version }}
+           
+            # git hash tag
+            type=raw,value=${{ env.GIT_HASH }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
@@ -115,123 +120,8 @@ jobs:
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
       - name: Sign the container image
-        run: cosign sign --yes ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+        run: cosign sign --yes ${{ env.REGISTRY_IMAGE }}:${{ env.GIT_HASH }}
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
-
-  musl-build-image:
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            os: ubuntu-latest
-          - platform: linux/arm64
-            os: ubuntu-22.04-arm
-    steps:
-    - name: Prepare
-      run: |
-        platform=${{ matrix.platform }}
-        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-        echo "VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
-
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY_IMAGE }}-musl
-
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build and push by digest
-      id: build
-      uses: docker/build-push-action@v6
-      with:
-        platforms: ${{ matrix.platform }}
-        labels: ${{ steps.meta.outputs.labels }}
-        tags: ${{ env.REGISTRY_IMAGE }}
-        outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-        cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-musl
-        cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-musl,mode=max
-        build-args: |
-          BUILDER=musl
-
-    - name: Export digest
-      run: |
-        mkdir -p ${{ runner.temp }}/digests-musl
-        digest="${{ steps.build.outputs.digest }}"
-        touch "${{ runner.temp }}/digests-musl/${digest#sha256:}"
-
-    - name: Upload digest
-      uses: actions/upload-artifact@v4
-      with:
-        name: digests-musl-${{ env.PLATFORM_PAIR }}
-        path: ${{ runner.temp }}/digests-musl/*
-        if-no-files-found: error
-        retention-days: 1
-
-  musl-push-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-    needs:
-      - musl-build-image
-    steps:
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v3.9.2
-
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: ${{ runner.temp }}/digests-musl
-          pattern: digests-musl*
-          merge-multiple: true
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=semver,pattern={{version}}
-            # use custom value instead of git tag
-            type=semver,pattern={{version}},value=${{ github.event.inputs.version }}
-
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests-musl
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + . + "-musl") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-
-      - name: Sign the container image
-        run: cosign sign --yes ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}-musl
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}-musl
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ env.GIT_HASH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,15 +29,6 @@ jobs:
         echo "VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
         echo "GIT_HASH=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY_IMAGE }}
-        tags: |
-          # git hash + platform tag
-          type=raw,value=${{ env.GIT_HASH }}-${{ env.PLATFORM_PAIR }}
-
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -53,8 +44,6 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         platforms: ${{ matrix.platform }}
-        labels: ${{ steps.meta.outputs.labels }}
-        tags: ${{ steps.meta.outputs.tags }}
         outputs: type=image,push-by-digest=true,name-canonical=true,push=true
         cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache
         cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         platforms: ${{ matrix.platform }}
+        tags: ${{ env.REGISTRY_IMAGE }}:${{ env.GIT_HASH }}-${{ env.PLATFORM_PAIR }}
         outputs: type=image,push-by-digest=true,name-canonical=true,push=true
         cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache
         cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       uses: docker/metadata-action@v5
       with:
         images: ${{ env.REGISTRY_IMAGE }}
+        tags: |
+          # git hash + platform tag
+          type=raw,value=${{ env.GIT_HASH }}-${{ env.PLATFORM_PAIR }}
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -51,7 +54,7 @@ jobs:
       with:
         platforms: ${{ matrix.platform }}
         labels: ${{ steps.meta.outputs.labels }}
-        tags: ${{ env.REGISTRY_IMAGE }}
+        tags: ${{ steps.meta.outputs.tags }}
         outputs: type=image,push-by-digest=true,name-canonical=true,push=true
         cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache
         cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache,mode=max
@@ -109,9 +112,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-           
-            # git hash tag
+            # git hash tag (multi-platform manifest)
             type=raw,value=${{ env.GIT_HASH }}
+            # git hash with platform-specific tags
+            type=raw,value=${{ env.GIT_HASH }}-linux-amd64
+            type=raw,value=${{ env.GIT_HASH }}-linux-arm64
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,31 +39,18 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Build and push by digest
+    - name: Build and push
       id: build
       uses: docker/build-push-action@v6
       with:
         platforms: ${{ matrix.platform }}
         tags: ${{ env.REGISTRY_IMAGE }}:${{ env.GIT_HASH }}-${{ env.PLATFORM_PAIR }}
-        outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+        push: true
         cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache
         cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache,mode=max
 
-    - name: Export digest
-      run: |
-        mkdir -p ${{ runner.temp }}/digests
-        digest="${{ steps.build.outputs.digest }}"
-        touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
-    - name: Upload digest
-      uses: actions/upload-artifact@v4
-      with:
-        name: digests-${{ env.PLATFORM_PAIR }}
-        path: ${{ runner.temp }}/digests/*
-        if-no-files-found: error
-        retention-days: 1
-
-  push-image:
+  create-manifest:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,13 +66,6 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2
 
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-linux-*
-          merge-multiple: true
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -96,23 +76,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            # git hash tag (multi-platform manifest)
-            type=raw,value=${{ env.GIT_HASH }}
-            # git hash with platform-specific tags
-            type=raw,value=${{ env.GIT_HASH }}-linux-amd64
-            type=raw,value=${{ env.GIT_HASH }}-linux-arm64
-
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
+      - name: Create multi-platform manifest
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY_IMAGE }}:${{ env.GIT_HASH }} \
+            ${{ env.REGISTRY_IMAGE }}:${{ env.GIT_HASH }}-linux-amd64 \
+            ${{ env.REGISTRY_IMAGE }}:${{ env.GIT_HASH }}-linux-arm64
 
       - name: Sign the container image
         run: cosign sign --yes ${{ env.REGISTRY_IMAGE }}:${{ env.GIT_HASH }}


### PR DESCRIPTION
Removed unnecessary push tag triggers and inputs from the release workflow. Updated the registry image path to reflect the new repository structure.